### PR TITLE
improvements

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -138,5 +138,15 @@
       "address": "0x4AD2F4CcA2682cBB5B950d660dD458a1D3f1bAaD",
       "startBlock": 14377316
     }
+  },
+  "unichain-mainnet": {
+    "PoolManager": {
+      "address": "0x1F98400000000000000000000000000000000004",
+      "startBlock": 25500
+    },
+    "PositionManager": {
+      "address": "0x4529A01c7A0410167c5740C487A8DE60232617bf",
+      "startBlock": 6819670
+    }
   }
 }

--- a/src/mappings/modifyLiquidity.ts
+++ b/src/mappings/modifyLiquidity.ts
@@ -46,10 +46,23 @@ export function handleModifyLiquidityHelper(
 
   if (token0 && token1) {
     const currTick: i32 = pool.tick!.toI32()
+    const currSqrtPriceX96 = pool.sqrtPrice
 
     // Get the amounts using the getAmounts function
-    const amount0Raw = getAmount0(event.params.tickLower, event.params.tickUpper, currTick, event.params.liquidityDelta)
-    const amount1Raw = getAmount1(event.params.tickLower, event.params.tickUpper, currTick, event.params.liquidityDelta)
+    const amount0Raw = getAmount0(
+      event.params.tickLower,
+      event.params.tickUpper,
+      currTick,
+      event.params.liquidityDelta,
+      currSqrtPriceX96,
+    )
+    const amount1Raw = getAmount1(
+      event.params.tickLower,
+      event.params.tickUpper,
+      currTick,
+      event.params.liquidityDelta,
+      currSqrtPriceX96,
+    )
     const amount0 = convertTokenToDecimal(amount0Raw, token0.decimals)
     const amount1 = convertTokenToDecimal(amount1Raw, token1.decimals)
 

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -271,7 +271,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       stablecoinWrappedNativePoolId: '0x4c9dff5169d88f7fbf5e43fc8e2eb56bf9791785729b9fc8c22064a47af12052', // https://bscscan.com/tx/0x36c1e4c7b4105a0be337addc32b5564dd3494fccfe331bf9fe7c647163d27d05#eventlog
       stablecoinIsToken0: true,
       wrappedNativeAddress: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', // WBNB
-      minimumNativeLocked: BigDecimal.fromString('100'),
+      minimumNativeLocked: BigDecimal.fromString('10'),
       stablecoinAddresses: [
         '0x55d398326f99059ff775485246999027b3197955', // USDT
         '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d', // USDC

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -187,6 +187,7 @@ export function getSubgraphConfig(): SubgraphConfig {
         '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1', // DAI
         '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9', // USDT
         '0xaf88d065e77c8cc2239327c5edb3a432268e5831', // USDC
+        '0x0000000000000000000000000000000000000000', // Native ETH
       ],
       tokenOverrides: [
         {
@@ -223,6 +224,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       whitelistTokens: [
         '0x4200000000000000000000000000000000000006', // WETH
         '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', // USDC
+        '0x0000000000000000000000000000000000000000', // Native ETH
       ],
       tokenOverrides: [],
       poolsToSkip: [],
@@ -251,6 +253,7 @@ export function getSubgraphConfig(): SubgraphConfig {
         '0x2791bca1f2de4661ed88a30c99a7a9449aa84174', // USDC.e
         '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063', // DAI
         '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359', // USDC
+        '0x0000000000000000000000000000000000000000', // Native POL
       ],
       tokenOverrides: [],
       poolsToSkip: [],
@@ -276,6 +279,7 @@ export function getSubgraphConfig(): SubgraphConfig {
         '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', // WBNB
         '0x55d398326f99059ff775485246999027b3197955', // USDT
         '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d', // USDC
+        '0x0000000000000000000000000000000000000000', // Native BNB
       ],
       tokenOverrides: [],
       poolsToSkip: [],
@@ -309,6 +313,7 @@ export function getSubgraphConfig(): SubgraphConfig {
         '0x50c5725949a6f0c72e6c4a641f24049a917db0cb', // LYRA
         '0x68f180fcce6836688e9084f035309e29bf0a2095', // WBTC
         '0x0b2c639c533813f4aa9d7837caf62653d097ff85', // USDC
+        '0x0000000000000000000000000000000000000000', // Native ETH
       ],
       tokenOverrides: [
         {
@@ -350,6 +355,7 @@ export function getSubgraphConfig(): SubgraphConfig {
         '0xc7198437980c041c805a1edcba50c1ce5db95118', // USDT_E
         '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7', // USDT
         '0x130966628846bfd36ff31a822705796e8cb8c18d', // MIM
+        '0x0000000000000000000000000000000000000000', // Native AVX
       ],
       tokenOverrides: [],
       poolsToSkip: [],
@@ -376,6 +382,7 @@ export function getSubgraphConfig(): SubgraphConfig {
         '0x03c7054bcb39f7b2e5b2c7acb37583e32d70cfa3', // WBTC
         '0x2cfc85d8e48f8eab294be644d9e25c3030863003', // WLD
         '0x859dbe24b90c9f2f7742083d3cf59ca41f55be5d', // sDAI
+        '0x0000000000000000000000000000000000000000', // Native ETH
       ],
       tokenOverrides: [],
       poolsToSkip: [],
@@ -399,6 +406,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       whitelistTokens: [
         '0x4200000000000000000000000000000000000006', // WETH
         '0xcccccccc7021b32ebb4e8c08314bd62f7c653ec4', // USDzC
+        '0x0000000000000000000000000000000000000000', // Native ETH
       ],
       tokenOverrides: [],
       poolsToSkip: [],
@@ -506,6 +514,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       whitelistTokens: [
         '0x4300000000000000000000000000000000000004', // WETH
         '0x4300000000000000000000000000000000000003', // USDB
+        '0x0000000000000000000000000000000000000000', // Native ETH
       ],
       tokenOverrides: [],
       poolsToSkip: [],

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -22,6 +22,7 @@ const WORLDCHAIN_MAINNET_NETWORK_NAME = 'worldchain-mainnet'
 const ZORA_MAINNET_NETWORK_NAME = 'zora-mainnet'
 const MAINNET_NETWORK_NAME = 'mainnet'
 const BLAST_MAINNET_NETWORK_NAME = 'blast-mainnet'
+const UNICHAIN_MAINNET_NETWORK_NAME = 'unichain-mainnet'
 // Note: All token and pool addresses should be lowercased!
 export class SubgraphConfig {
   // deployment address
@@ -241,7 +242,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       stablecoinWrappedNativePoolId: '0x15484bc239f7554e7ead77c45834c722d3f74a9b20826fdf21bbb1b026444286', // https://polygonscan.com/tx/0x6c94e24c0ddff6dd9bfa860561945330c81df85ebb4b1ecf75a459b016719314
       stablecoinIsToken0: false,
       wrappedNativeAddress: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270', // WMATIC
-      minimumNativeLocked: BigDecimal.fromString('1'),
+      minimumNativeLocked: BigDecimal.fromString('20000'),
       stablecoinAddresses: [
         '0x2791bca1f2de4661ed88a30c99a7a9449aa84174', // USDC.e
         '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063', // DAI
@@ -270,7 +271,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       stablecoinWrappedNativePoolId: '0x4c9dff5169d88f7fbf5e43fc8e2eb56bf9791785729b9fc8c22064a47af12052', // https://bscscan.com/tx/0x36c1e4c7b4105a0be337addc32b5564dd3494fccfe331bf9fe7c647163d27d05#eventlog
       stablecoinIsToken0: true,
       wrappedNativeAddress: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', // WBNB
-      minimumNativeLocked: BigDecimal.fromString('1'),
+      minimumNativeLocked: BigDecimal.fromString('100'),
       stablecoinAddresses: [
         '0x55d398326f99059ff775485246999027b3197955', // USDT
         '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d', // USDC
@@ -337,7 +338,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       stablecoinWrappedNativePoolId: '0xd7a8035ddd9ec1dba25e3b27b685927fe63d65281f21c1c1d21d122fc48caeb7', // https://snowtrace.io/tx/0x008bbcac5d411e48621c94f75f3dedf025a031d2633a548fb372f45f73db111d/eventlog?chainid=43114
       stablecoinIsToken0: false,
       wrappedNativeAddress: '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7', // WAVAX
-      minimumNativeLocked: BigDecimal.fromString('1'),
+      minimumNativeLocked: BigDecimal.fromString('100'),
       stablecoinAddresses: [
         '0xd586e7f844cea2f87f50152665bcbc2c279d8d70', // DAI_E
         '0xba7deebbfc5fa1100fb055a87773e1e99cd3507a', // DAI
@@ -514,6 +515,32 @@ export function getSubgraphConfig(): SubgraphConfig {
       whitelistTokens: [
         '0x4300000000000000000000000000000000000004', // WETH
         '0x4300000000000000000000000000000000000003', // USDB
+        '0x0000000000000000000000000000000000000000', // Native ETH
+      ],
+      tokenOverrides: [],
+      poolsToSkip: [],
+      poolMappings: [],
+      nativeTokenDetails: {
+        symbol: 'ETH',
+        name: 'Ethereum',
+        decimals: BigInt.fromI32(18),
+      },
+    }
+  } else if (selectedNetwork == UNICHAIN_MAINNET_NETWORK_NAME) {
+    return {
+      poolManagerAddress: '0x1f98400000000000000000000000000000000004',
+      stablecoinWrappedNativePoolId: '0xe452cd9b74c641fb3f6c2ff593c3d34f90f2da9155e5ab66798f72bee4f5fe8e',
+      stablecoinIsToken0: false,
+      wrappedNativeAddress: '0x0000000000000000000000000000000000000000', // Native ETH
+      minimumNativeLocked: BigDecimal.fromString('1'),
+      stablecoinAddresses: [
+        '0x078d782b760474a361dda0af3839290b0ef57ad6', // USDC
+        '0x20cab320a855b39f724131c69424240519573f81', // DAI
+      ],
+      whitelistTokens: [
+        '0x4200000000000000000000000000000000000006', // WETH
+        '0x078d782b760474a361dda0af3839290b0ef57ad6', // USDC
+        '0x20cab320a855b39f724131c69424240519573f81', // DAI
         '0x0000000000000000000000000000000000000000', // Native ETH
       ],
       tokenOverrides: [],

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -529,7 +529,7 @@ export function getSubgraphConfig(): SubgraphConfig {
   } else if (selectedNetwork == UNICHAIN_MAINNET_NETWORK_NAME) {
     return {
       poolManagerAddress: '0x1f98400000000000000000000000000000000004',
-      stablecoinWrappedNativePoolId: '0xe452cd9b74c641fb3f6c2ff593c3d34f90f2da9155e5ab66798f72bee4f5fe8e',
+      stablecoinWrappedNativePoolId: '0x25939956ef14a098d95051d86c75890cfd623a9eeba055e46d8dd9135980b37c',
       stablecoinIsToken0: false,
       wrappedNativeAddress: '0x0000000000000000000000000000000000000000', // Native ETH
       minimumNativeLocked: BigDecimal.fromString('1'),

--- a/src/utils/liquidityMath/liquidityAmounts.ts
+++ b/src/utils/liquidityMath/liquidityAmounts.ts
@@ -5,17 +5,23 @@ import { SqrtPriceMath } from './sqrtPriceMath'
 import { TickMath } from './tickMath'
 
 // https://github.com/Uniswap/v3-sdk/blob/4e16fe8e56c8c26541545f138c89133794c7ce72/src/entities/position.ts#L68-L127
-export function getAmount0(tickLower: i32, tickUpper: i32, currTick: i32, amount: BigInt): BigInt {
+export function getAmount0(
+  tickLower: i32,
+  tickUpper: i32,
+  currTick: i32,
+  amount: BigInt,
+  currSqrtPriceX96: BigInt,
+): BigInt {
   const sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(tickLower)
   const sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(tickUpper)
-  const sqrtRatioCurrentX96 = TickMath.getSqrtRatioAtTick(currTick)
 
   let amount0 = ZERO_BI
+  const roundUp = amount.gt(ZERO_BI)
 
   if (currTick < tickLower) {
-    amount0 = SqrtPriceMath.getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, amount, true)
+    amount0 = SqrtPriceMath.getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, amount, roundUp)
   } else if (currTick < tickUpper) {
-    amount0 = SqrtPriceMath.getAmount0Delta(sqrtRatioCurrentX96, sqrtRatioBX96, amount, true)
+    amount0 = SqrtPriceMath.getAmount0Delta(currSqrtPriceX96, sqrtRatioBX96, amount, roundUp)
   } else {
     amount0 = ZERO_BI
   }
@@ -23,19 +29,25 @@ export function getAmount0(tickLower: i32, tickUpper: i32, currTick: i32, amount
   return amount0
 }
 
-export function getAmount1(tickLower: i32, tickUpper: i32, currTick: i32, amount: BigInt): BigInt {
+export function getAmount1(
+  tickLower: i32,
+  tickUpper: i32,
+  currTick: i32,
+  amount: BigInt,
+  currSqrtPriceX96: BigInt,
+): BigInt {
   const sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(tickLower)
   const sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(tickUpper)
-  const sqrtRatioCurrentX96 = TickMath.getSqrtRatioAtTick(currTick)
 
   let amount1 = ZERO_BI
+  const roundUp = amount.gt(ZERO_BI)
 
   if (currTick < tickLower) {
     amount1 = ZERO_BI
   } else if (currTick < tickUpper) {
-    amount1 = SqrtPriceMath.getAmount1Delta(sqrtRatioAX96, sqrtRatioCurrentX96, amount, true)
+    amount1 = SqrtPriceMath.getAmount1Delta(sqrtRatioAX96, currSqrtPriceX96, amount, roundUp)
   } else {
-    amount1 = SqrtPriceMath.getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, amount, true)
+    amount1 = SqrtPriceMath.getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, amount, roundUp)
   }
 
   return amount1

--- a/tests/utils/liquidityMath/liquidityAmount.test.ts
+++ b/tests/utils/liquidityMath/liquidityAmount.test.ts
@@ -11,56 +11,92 @@ describe('Amount Calculations', () => {
 
   describe('getAmount0', () => {
     test('returns correct amount when current tick is below lower tick', () => {
-      const result = getAmount0(-10, 10, -20, BigInt.fromI32(1000000))
+      const result = getAmount0(
+        -10,
+        10,
+        -20,
+        BigInt.fromI32(1000000),
+        BigInt.fromString('79148977909814923576066331265'),
+      )
       assert.bigIntEquals(result, BigInt.fromI32(1000))
     })
 
     test('returns correct amount when current tick is between lower and upper tick', () => {
-      const result = getAmount0(-10, 10, 0, BigInt.fromI32(1000000))
+      const result = getAmount0(-10, 10, 0, BigInt.fromI32(1000000), BigInt.fromString('79228162514264337593543950336'))
       assert.assertTrue(result > ZERO_BI, 'Result should be greater than zero')
       assert.assertTrue(result < BigInt.fromI32(1000000), 'Result should be less than 1000000')
     })
 
     test('returns zero when current tick is above upper tick', () => {
-      const result = getAmount0(-10, 10, 20, BigInt.fromI32(1000000))
+      const result = getAmount0(
+        -10,
+        10,
+        20,
+        BigInt.fromI32(1000000),
+        BigInt.fromString('79307426338960776842885539845'),
+      )
       assert.bigIntEquals(result, ZERO_BI)
     })
 
     test('handles edge case with minimum tick', () => {
-      const result = getAmount0(-887272, 0, -887272, BigInt.fromI32(1000000))
+      const result = getAmount0(-887272, 0, -887272, BigInt.fromI32(1000000), BigInt.fromString('4295128739'))
       assert.assertTrue(result > ZERO_BI, 'Result should be greater than zero')
     })
 
     test('handles edge case with maximum tick', () => {
-      const result = getAmount0(0, 887272, 887272, BigInt.fromI32(1000000))
+      const result = getAmount0(
+        0,
+        887272,
+        887272,
+        BigInt.fromI32(1000000),
+        BigInt.fromString('1461446703485210103287273052203988822378723970342'),
+      )
       assert.bigIntEquals(result, ZERO_BI)
     })
   })
 
   describe('getAmount1', () => {
     test('returns zero when current tick is below lower tick', () => {
-      const result = getAmount1(-10, 10, -20, BigInt.fromI32(1000000))
+      const result = getAmount1(
+        -10,
+        10,
+        -20,
+        BigInt.fromI32(1000000),
+        BigInt.fromString('79148977909814923576066331265'),
+      )
       assert.bigIntEquals(result, ZERO_BI)
     })
 
     test('returns correct amount when current tick is between lower and upper tick', () => {
-      const result = getAmount1(-10, 10, 0, BigInt.fromI32(1000000))
+      const result = getAmount1(-10, 10, 0, BigInt.fromI32(1000000), BigInt.fromString('79228162514264337593543950336'))
       assert.assertTrue(result > ZERO_BI, 'Result should be greater than zero')
       assert.assertTrue(result < BigInt.fromI32(1000000), 'Result should be less than 1000000')
     })
 
     test('returns correct amount when current tick is above upper tick', () => {
-      const result = getAmount1(-10, 10, 20, BigInt.fromI32(1000000))
+      const result = getAmount1(
+        -10,
+        10,
+        20,
+        BigInt.fromI32(1000000),
+        BigInt.fromString('79307426338960776842885539845'),
+      )
       assert.bigIntEquals(result, BigInt.fromI32(1000))
     })
 
     test('handles edge case with minimum tick', () => {
-      const result = getAmount1(-887272, 0, -887272, BigInt.fromI32(1000000))
+      const result = getAmount1(-887272, 0, -887272, BigInt.fromI32(1000000), BigInt.fromString('4295128739'))
       assert.bigIntEquals(result, ZERO_BI)
     })
 
     test('handles edge case with maximum tick', () => {
-      const result = getAmount1(0, 887272, 887272, BigInt.fromI32(1000000))
+      const result = getAmount1(
+        0,
+        887272,
+        887272,
+        BigInt.fromI32(1000000),
+        BigInt.fromString('1461446703485210103287273052203988822378723970342'),
+      )
       assert.assertTrue(result > ZERO_BI, 'Result should be greater than zero')
     })
   })


### PR DESCRIPTION
- for getting modifyLiq amounts, use pool's `currSqrtPriceX96` instead of deriving the theoretical price from `currTick` to ensure more accurate amount0/amount1 values. 
- for getting modifyLiq amounts, `roundUp` only if liquidity delta is positive ([ref](https://github.com/Uniswap/v4-core/blob/e50237c43811bd9b526eff40f26772152a42daba/src/libraries/SqrtPriceMath.sol#L266-L270))
- add native token (0x0000...) to whitelistPools for chains that were missing it, to ensure broader pricing data coverage. 