### PR TITLE
Fix Swap id comment

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -184,7 +184,7 @@ type Transaction @entity {
 }
 
 type Swap @entity {
-  # transaction hash + "#" + index in swaps Transaction array
+  # transaction hash + "-" + index in swaps Transaction array
   id: ID!
   # pointer to transaction
   transaction: Transaction!


### PR DESCRIPTION
The Swap id uses a hyphen instead of a hash as can be seen in the [swap.ts file](https://github.com/Uniswap/v4-subgraph/blob/main/src/mappings/swap.ts#L147):
```
const swap = new Swap(transaction.id + '-' + event.logIndex.toString())
```
