### PR TITLE
Hotfix for zora on base

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,4 @@
-type PoolManager @entity {
+type PoolManager @entity (immutable: false){
   # poolManager address
   id: ID!
   # amount of pools created
@@ -28,13 +28,13 @@ type PoolManager @entity {
 }
 
 # stores for USD calculations
-type Bundle @entity {
+type Bundle @entity (immutable: false){
   id: ID!
   # price of ETH in usd
   ethPriceUSD: BigDecimal!
 }
 
-type Token @entity {
+type Token @entity (immutable: false){
   # token address
   id: ID!
   # token symbol
@@ -73,7 +73,7 @@ type Token @entity {
   tokenDayData: [TokenDayData!]! @derivedFrom(field: "token")
 }
 
-type Pool @entity {
+type Pool @entity (immutable: false){
   # pool address
   id: ID!
   # creation
@@ -142,7 +142,7 @@ type Pool @entity {
   ticks: [Tick!]! @derivedFrom(field: "pool")
 }
 
-type Tick @entity {
+type Tick @entity (immutable: false){
   # format: <pool address>#<tick index>
   id: ID!
   # pool address
@@ -165,7 +165,7 @@ type Tick @entity {
   createdAtBlockNumber: BigInt!
 }
 
-type Transaction @entity {
+type Transaction @entity (immutable: true){
   # txn hash
   id: ID!
   # block txn was included in
@@ -183,7 +183,7 @@ type Transaction @entity {
   unsubscriptions: [Unsubscribe]! @derivedFrom(field: "transaction")
 }
 
-type Swap @entity {
+type Swap @entity (immutable: true){
   # transaction hash + "#" + index in swaps Transaction array
   id: ID!
   # pointer to transaction
@@ -216,7 +216,7 @@ type Swap @entity {
   logIndex: BigInt
 }
 
-type ModifyLiquidity @entity {
+type ModifyLiquidity @entity (immutable: true){
   # transaction hash + "#" + index in mints Transaction array
   id: ID!
   # which txn the ModifyLiquidity was included in
@@ -252,7 +252,7 @@ type ModifyLiquidity @entity {
 }
 
 # Data accumulated and condensed into day stats for all of Uniswap
-type UniswapDayData @entity {
+type UniswapDayData @entity (immutable: false){
   # timestamp rounded to current day by dividing by 86400
   id: ID!
   # timestamp rounded to current day by dividing by 86400
@@ -272,7 +272,7 @@ type UniswapDayData @entity {
 }
 
 # Data accumulated and condensed into day stats for each pool
-type PoolDayData @entity {
+type PoolDayData @entity (immutable: false){
   # timestamp rounded to current day by dividing by 86400
   id: ID!
   # timestamp rounded to current day by dividing by 86400
@@ -312,7 +312,7 @@ type PoolDayData @entity {
 }
 
 # hourly stats tracker for pool
-type PoolHourData @entity {
+type PoolHourData @entity (immutable: false){
   # format: <pool address>-<timestamp>
   id: ID!
   # unix timestamp for start of hour
@@ -351,7 +351,7 @@ type PoolHourData @entity {
   close: BigDecimal!
 }
 
-type TokenDayData @entity {
+type TokenDayData @entity (immutable: false){
   # token address concatendated with date
   id: ID!
   # timestamp rounded to current day by dividing by 86400
@@ -382,7 +382,7 @@ type TokenDayData @entity {
   close: BigDecimal!
 }
 
-type TokenHourData @entity {
+type TokenHourData @entity (immutable: false){
   # token address concatendated with date
   id: ID!
   # unix timestamp for start of hour
@@ -413,7 +413,7 @@ type TokenHourData @entity {
   close: BigDecimal!
 }
 
-type Position @entity {
+type Position @entity (immutable: false){
   # tokenId
   id: ID!
   # tokenId
@@ -432,7 +432,7 @@ type Position @entity {
   transfers: [Transfer!]! @derivedFrom(field: "position")
 }
 
-type Subscribe @entity {
+type Subscribe @entity (immutable: true){
   # transaction hash + '-' + log index
   id: ID!
   # token id of position subscribed to
@@ -451,7 +451,7 @@ type Subscribe @entity {
   position: Position!
 }
 
-type Unsubscribe @entity {
+type Unsubscribe @entity (immutable: true){
   # transaction hash + '-' + log index
   id: ID!
   # token id of position unsubscribed from
@@ -470,7 +470,7 @@ type Unsubscribe @entity {
   position: Position!
 }
 
-type Transfer @entity {
+type Transfer @entity (immutable: true){
   # transaction hash + '-' + log index
   id: ID!
   # token id of position
@@ -491,15 +491,3 @@ type Transfer @entity {
   position: Position!
 }
 
-type EulerSwapHook @entity {
-  # Composite key = eulerAccount-asset0-asset1
-  id: ID!
-  # The latest hook address for this key
-  hook: String!
-  # address of the euler account
-  eulerAccount: String!
-  # address of asset0
-  asset0: String!
-  # address of asset1
-  asset1: String!
-}

--- a/src/mappings/euler.ts
+++ b/src/mappings/euler.ts
@@ -1,53 +1,47 @@
-import { store } from '@graphprotocol/graph-ts'
+// import { EulerSwapHook } from '../types/schema'
 
-import {
-  PoolDeployed as HookDeployedEvent,
-  PoolUninstalled as HookUninstalledEvent,
-} from '../types/EulerSwapFactory/EulerSwapFactory'
-import { EulerSwapHook } from '../types/schema'
+// export function handleHookDeployed(event: HookDeployedEvent): void {
+//   // ──────────────────────────────────────────────────────────────
+//   // Build the composite ID: eulerAccount-asset0-asset1
+//   // ──────────────────────────────────────────────────────────────
+//   const account = event.params.eulerAccount.toHexString()
+//   const asset0 = event.params.asset0.toHexString()
+//   const asset1 = event.params.asset1.toHexString()
 
-export function handleHookDeployed(event: HookDeployedEvent): void {
-  // ──────────────────────────────────────────────────────────────
-  // Build the composite ID: eulerAccount-asset0-asset1
-  // ──────────────────────────────────────────────────────────────
-  const account = event.params.eulerAccount.toHexString()
-  const asset0 = event.params.asset0.toHexString()
-  const asset1 = event.params.asset1.toHexString()
+//   const id = `${account}-${asset0}-${asset1}` // <- entity id
 
-  const id = `${account}-${asset0}-${asset1}` // <- entity id
+//   // ──────────────────────────────────────────────────────────────
+//   // Load (or create) the row for this tuple
+//   // ──────────────────────────────────────────────────────────────
+//   let entity = EulerSwapHook.load(id)
+//   if (entity == null) {
+//     entity = new EulerSwapHook(id)
+//     entity.eulerAccount = account
+//     entity.asset0 = asset0
+//     entity.asset1 = asset1
+//   }
 
-  // ──────────────────────────────────────────────────────────────
-  // Load (or create) the row for this tuple
-  // ──────────────────────────────────────────────────────────────
-  let entity = EulerSwapHook.load(id)
-  if (entity == null) {
-    entity = new EulerSwapHook(id)
-    entity.eulerAccount = account
-    entity.asset0 = asset0
-    entity.asset1 = asset1
-  }
+//   // Always overwrite the hook address so the latest hook is used
+//   entity.hook = event.params.pool.toHexString()
 
-  // Always overwrite the hook address so the latest hook is used
-  entity.hook = event.params.pool.toHexString()
+//   entity.save()
+// }
 
-  entity.save()
-}
+// export function handleHookUninstalled(event: HookUninstalledEvent): void {
+//   // ──────────────────────────────────────────────────────────────
+//   // Build the composite ID: eulerAccount-asset0-asset1
+//   // ──────────────────────────────────────────────────────────────
+//   const account = event.params.eulerAccount.toHexString()
+//   const asset0 = event.params.asset0.toHexString()
+//   const asset1 = event.params.asset1.toHexString()
 
-export function handleHookUninstalled(event: HookUninstalledEvent): void {
-  // ──────────────────────────────────────────────────────────────
-  // Build the composite ID: eulerAccount-asset0-asset1
-  // ──────────────────────────────────────────────────────────────
-  const account = event.params.eulerAccount.toHexString()
-  const asset0 = event.params.asset0.toHexString()
-  const asset1 = event.params.asset1.toHexString()
+//   const id = `${account}-${asset0}-${asset1}` // <- entity id
 
-  const id = `${account}-${asset0}-${asset1}` // <- entity id
-
-  // ──────────────────────────────────────────────────────────────
-  // Load (or create) the row for this tuple
-  // ──────────────────────────────────────────────────────────────
-  const entity = EulerSwapHook.load(id)
-  if (entity != null && entity.hook == event.params.pool.toHexString()) {
-    store.remove('EulerSwapHook', id)
-  }
-}
+//   // ──────────────────────────────────────────────────────────────
+//   // Load (or create) the row for this tuple
+//   // ──────────────────────────────────────────────────────────────
+//   const entity = EulerSwapHook.load(id)
+//   if (entity != null && entity.hook == event.params.pool.toHexString()) {
+//     store.remove('EulerSwapHook', id)
+//   }
+// }

--- a/src/mappings/index.ts
+++ b/src/mappings/index.ts
@@ -1,4 +1,4 @@
-import { handleHookDeployed, handleHookUninstalled } from './euler'
+//import { handleHookDeployed, handleHookUninstalled } from './euler'
 import { handleModifyLiquidity } from './modifyLiquidity'
 import { handleInitialize } from './poolManager'
 import { handleSubscription } from './subscribe'
@@ -7,8 +7,8 @@ import { handleTransfer } from './transfer'
 import { handleUnsubscription } from './unsubscribe'
 
 export {
-  handleHookDeployed,
-  handleHookUninstalled,
+  //handleHookDeployed,
+  //handleHookUninstalled,
   handleInitialize,
   handleModifyLiquidity,
   handleSubscription,

--- a/src/mappings/swap.ts
+++ b/src/mappings/swap.ts
@@ -47,6 +47,24 @@ export function handleSwapHelper(event: SwapEvent, subgraphConfig: SubgraphConfi
   const token1 = Token.load(pool.token1)
 
   if (token0 && token1) {
+    // Backfill emppty tokens' whitelist pools to account for grafting to a point later than the block where the pool was initialized
+    if (token0.whitelistPools === null) {
+      if (whitelistTokens.includes(token1.id)) {
+        const newPools = token0.whitelistPools
+        newPools.push(pool.id)
+        token0.whitelistPools = newPools
+      }
+    }
+
+    if (token1.whitelistPools === null) {
+      // update white listed pools
+      if (whitelistTokens.includes(token0.id)) {
+        const newPools = token1.whitelistPools
+        newPools.push(pool.id)
+        token1.whitelistPools = newPools
+      }
+    }
+
     // amounts - 0/1 are token deltas: can be positive or negative
     // Unlike V3, a negative amount represents that amount is being sent to the pool and vice versa, so invert the sign
     const amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals).times(BigDecimal.fromString('-1'))

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,14 +6,17 @@ schema:
 features:
   - nonFatalErrors
   - grafting
+graft: 
+  base: QmS1ehFzXTD9eA1f1EgjZvdyAj2EHtVNMrEN91H3pLuHMy
+  block: 33415500
 dataSources:
   - kind: ethereum/contract
     name: PoolManager
-    network: mainnet
+    network: base
     source:
       abi: PoolManager
-      address: "0x000000000004444c5dc75cB358380D2e3dE08A90"
-      startBlock: 21688329
+      address: "0x498581fF718922c3f8e6A244956aF099B2652b2b"
+      startBlock: 25350988
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -43,11 +46,11 @@ dataSources:
           handler: handleSwap
   - kind: ethereum/contract
     name: PositionManager
-    network: mainnet
+    network: base
     source:
       abi: PositionManager
-      address: "0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e"
-      startBlock: 21689089
+      address: "0x7C5f5A4bBd8fD63184577525326123B519429bDc"
+      startBlock: 25350993
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -65,25 +68,25 @@ dataSources:
           handler: handleUnsubscription
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
-  - kind: ethereum/contract
-    name: EulerSwapFactory
-    network: mainnet
-    source:
-      abi: EulerSwapFactory
-      address: "0xb013be1D0D380C13B58e889f412895970A2Cf228"
-      startBlock: 22676162
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      file: ./src/mappings/index.ts
-      entities:
-        - Position
-      abis:
-        - name: EulerSwapFactory
-          file: ./abis/EulerSwapFactory.json
-      eventHandlers:
-        - event: PoolDeployed(indexed address,indexed address,indexed address,address)
-          handler: handleHookDeployed
-        - event: PoolUninstalled(indexed address,indexed address,indexed address,address)
-          handler: handleHookUninstalled
+  # - kind: ethereum/contract
+  #   name: EulerSwapFactory
+  #   network: mainnet
+  #   source:
+  #     abi: EulerSwapFactory
+  #     address: "0xb013be1D0D380C13B58e889f412895970A2Cf228"
+  #     startBlock: 22676162
+  #   mapping:
+  #     kind: ethereum/events
+  #     apiVersion: 0.0.7
+  #     language: wasm/assemblyscript
+  #     file: ./src/mappings/index.ts
+  #     entities:
+  #       - Position
+  #     abis:
+  #       - name: EulerSwapFactory
+  #         file: ./abis/EulerSwapFactory.json
+  #     eventHandlers:
+  #       - event: PoolDeployed(indexed address,indexed address,indexed address,address)
+  #         handler: handleHookDeployed
+  #       - event: PoolUninstalled(indexed address,indexed address,indexed address,address)
+  #         handler: handleHookUninstalled


### PR DESCRIPTION
Updates:
- Makes entities immutable when applicable
- Grafts to `QmS1ehFzXTD9eA1f1EgjZvdyAj2EHtVNMrEN91H3pLuHMy` as viable base subgraph on The Graph
- Includes Zora as a whitelist token
- Adds 'backfill' logic for `token.whitelistPool` where none exist during `handleSwap`. This catches and populates pools deployed prior to the graft block after their first swap event. 