### PR TITLE
Immutable Entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -491,7 +491,7 @@ type Transfer @entity (immutable: true){
   position: Position!
 }
 
-type EulerSwapHook @entity {
+type EulerSwapHook @entity (immutable: false){
   # Composite key = eulerAccount-asset0-asset1
   id: ID!
   # The latest hook address for this key

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,4 @@
-type PoolManager @entity {
+type PoolManager @entity (immutable: false){
   # poolManager address
   id: ID!
   # amount of pools created
@@ -28,13 +28,13 @@ type PoolManager @entity {
 }
 
 # stores for USD calculations
-type Bundle @entity {
+type Bundle @entity (immutable: false){
   id: ID!
   # price of ETH in usd
   ethPriceUSD: BigDecimal!
 }
 
-type Token @entity {
+type Token @entity (immutable: false){
   # token address
   id: ID!
   # token symbol
@@ -73,7 +73,7 @@ type Token @entity {
   tokenDayData: [TokenDayData!]! @derivedFrom(field: "token")
 }
 
-type Pool @entity {
+type Pool @entity (immutable: false){
   # pool address
   id: ID!
   # creation
@@ -142,7 +142,7 @@ type Pool @entity {
   ticks: [Tick!]! @derivedFrom(field: "pool")
 }
 
-type Tick @entity {
+type Tick @entity (immutable: false){
   # format: <pool address>#<tick index>
   id: ID!
   # pool address
@@ -165,7 +165,7 @@ type Tick @entity {
   createdAtBlockNumber: BigInt!
 }
 
-type Transaction @entity {
+type Transaction @entity (immutable: true){
   # txn hash
   id: ID!
   # block txn was included in
@@ -183,7 +183,7 @@ type Transaction @entity {
   unsubscriptions: [Unsubscribe]! @derivedFrom(field: "transaction")
 }
 
-type Swap @entity {
+type Swap @entity (immutable: true){
   # transaction hash + "#" + index in swaps Transaction array
   id: ID!
   # pointer to transaction
@@ -216,7 +216,7 @@ type Swap @entity {
   logIndex: BigInt
 }
 
-type ModifyLiquidity @entity {
+type ModifyLiquidity @entity (immutable: true){
   # transaction hash + "#" + index in mints Transaction array
   id: ID!
   # which txn the ModifyLiquidity was included in
@@ -252,7 +252,7 @@ type ModifyLiquidity @entity {
 }
 
 # Data accumulated and condensed into day stats for all of Uniswap
-type UniswapDayData @entity {
+type UniswapDayData @entity (immutable: false){
   # timestamp rounded to current day by dividing by 86400
   id: ID!
   # timestamp rounded to current day by dividing by 86400
@@ -272,7 +272,7 @@ type UniswapDayData @entity {
 }
 
 # Data accumulated and condensed into day stats for each pool
-type PoolDayData @entity {
+type PoolDayData @entity (immutable: false){
   # timestamp rounded to current day by dividing by 86400
   id: ID!
   # timestamp rounded to current day by dividing by 86400
@@ -312,7 +312,7 @@ type PoolDayData @entity {
 }
 
 # hourly stats tracker for pool
-type PoolHourData @entity {
+type PoolHourData @entity (immutable: false){
   # format: <pool address>-<timestamp>
   id: ID!
   # unix timestamp for start of hour
@@ -351,7 +351,7 @@ type PoolHourData @entity {
   close: BigDecimal!
 }
 
-type TokenDayData @entity {
+type TokenDayData @entity (immutable: false){
   # token address concatendated with date
   id: ID!
   # timestamp rounded to current day by dividing by 86400
@@ -382,7 +382,7 @@ type TokenDayData @entity {
   close: BigDecimal!
 }
 
-type TokenHourData @entity {
+type TokenHourData @entity (immutable: false){
   # token address concatendated with date
   id: ID!
   # unix timestamp for start of hour
@@ -413,7 +413,7 @@ type TokenHourData @entity {
   close: BigDecimal!
 }
 
-type Position @entity {
+type Position @entity (immutable: false){
   # tokenId
   id: ID!
   # tokenId
@@ -432,7 +432,7 @@ type Position @entity {
   transfers: [Transfer!]! @derivedFrom(field: "position")
 }
 
-type Subscribe @entity {
+type Subscribe @entity (immutable: true){
   # transaction hash + '-' + log index
   id: ID!
   # token id of position subscribed to
@@ -451,7 +451,7 @@ type Subscribe @entity {
   position: Position!
 }
 
-type Unsubscribe @entity {
+type Unsubscribe @entity (immutable: true){
   # transaction hash + '-' + log index
   id: ID!
   # token id of position unsubscribed from
@@ -470,7 +470,7 @@ type Unsubscribe @entity {
   position: Position!
 }
 
-type Transfer @entity {
+type Transfer @entity (immutable: true){
   # transaction hash + '-' + log index
   id: ID!
   # token id of position


### PR DESCRIPTION
Makes entities immutable where applicable. 

From the [Graph Docs](https://thegraph.com/docs/en/subgraphs/best-practices/immutable-entities-bytes-as-ids/#under-the-hood):

> Mutable entities have a ‘block range’ indicating their validity. Updating these entities requires the graph node to adjust the block range of previous versions, increasing database workload. Queries also need filtering to find only live entities. Immutable entities are faster because they are all live and since they won’t change, no checks or updates are required while writing, and no filtering is required during queries.