### PR TITLE
fix: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '18.x'
           registry-url: https://registry.npmjs.org
@@ -32,7 +32,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '18.x'
 
@@ -66,7 +66,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
## Summary

Pin all GitHub Actions references from mutable tags to immutable commit SHAs to mitigate supply chain attacks. Mutable tags can be force-pushed by upstream maintainers (or attackers who compromise their accounts), allowing arbitrary code execution in CI. This is the same class of attack vector exploited in the [axios/axios-dev supply chain incident](https://blog.phylum.io/axios-lottie-player-and-more-npm-supply-chain-attacks/).

## What changed

- **`.github/workflows/CI.yml`**: Pinned 6 action references across the `lint` and `build-and-test` jobs:
  - `actions/checkout@v4` -> `34e114876b0b11c390a56381ad16ebd13914f8d5`
  - `actions/setup-node@v3` -> `3235b876344d2a9aa001b8d1453c930bba69e610`
  - `actions/cache@v4` (x2) -> `0057852bfaa89a56745cba8c7296529d2fc39830`
  - `actions/checkout@v2` -> `ee0669bd1cc54295c223e0bb666b733df41de1c5`
  - `actions/setup-node@v2` -> `7c12f8017d5436eb855f1ed4399f037a36fbd9e8`
- **`trufflehog.yml`** and **`semgrep.yml`** were already SHA-pinned -- no changes needed.

## Test plan

- [x] Verified resolved SHAs via `gh api repos/{owner}/{repo}/git/ref/tags/{tag}`
- [x] Confirmed no tag objects needed dereferencing (all resolved directly to commits)
- [ ] CI should pass with pinned SHAs (functionally identical to tag references)

## Session context

Audited all 3 workflow files in `.github/workflows/`. Only `CI.yml` had unpinned tag references. The security-focused workflows (trufflehog, semgrep) were already properly pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>