### PR TITLE
update megaeth v4 to canonical deployment (4326)

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -203,12 +203,12 @@
   },
   "megaeth-mainnet": {
     "PoolManager": {
-      "address": "0x58dd83c317b03e6ebd72c3e912adf60a8e97aa95",
-      "startBlock": 3637446
+      "address": "0xacb7e78fa05d562e0a5d3089ec896d57d057d38e",
+      "startBlock": 7009653
     },
     "PositionManager": {
-      "address": "0xcae584c1f193cb3c090324ca8a1af4ce378e37e1",
-      "startBlock": 3637446
+      "address": "0x9ae0921e981aaa7308f176f8d4f9129b9247c89d",
+      "startBlock": 7009656
     }
   },
   "linea": {

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -694,7 +694,7 @@ export function getSubgraphConfig(): SubgraphConfig {
     const nativeToUSDT0 = '0xf1fc7e1b96823086b3821db02223910112d139b28c6a132befccada2a3ecae89'.toLowerCase()
 
     return {
-      poolManagerAddress: '0x58dd83c317b03e6ebd72c3e912adf60a8e97aa95'.toLowerCase(),
+      poolManagerAddress: '0xacb7e78fa05d562e0a5d3089ec896d57d057d38e'.toLowerCase(),
       stablecoinWrappedNativePoolId: nativeToUSDT0,
       stablecoinIsToken0: false,
       wrappedNativeAddress: WETH,


### PR DESCRIPTION
## Problem

The `megaeth-mainnet` v4 config points at the **stale early deployment** (PoolManager `0x58dd83c317b03e6ebd72c3e912adf60a8e97aa95`, ~block 3.63M) rather than the canonical v4 deployment. Same class of issue as [v3-subgraph#299](https://github.com/Uniswap/v3-subgraph/pull/299) and the v2 fix.

## Source of truth

[developers.uniswap.org/contracts/v4/deployments](https://developers.uniswap.org/contracts/v4/deployments) (chain id 4326), matches `Uniswap/contracts` `deployments/4326.md`:
- **PoolManager:** `0xacb7e78fa05d562e0a5d3089ec896d57d057d38e`
- **PositionManager:** `0x9ae0921e981aaa7308f176f8d4f9129b9247c89d`

## Changes

| File | Field | Before | After |
|---|---|---|---|
| `networks.json` | PoolManager.address | `0x58dd83c3…7aa95` | `0xacb7e78f…d38e` |
| `networks.json` | PoolManager.startBlock | `3637446` | `7009653` |
| `networks.json` | PositionManager.address | `0xcae584c1…e37e1` | `0x9ae0921e…c89d` |
| `networks.json` | PositionManager.startBlock | `3637446` | `7009656` |
| `src/utils/chains.ts` | `poolManagerAddress` (megaeth) | `0x58dd83c3…7aa95` | `0xacb7e78f…d38e` |

`stablecoinWrappedNativePoolId` is **left unchanged** — V4 poolIds are derived from the PoolKey, and `StateView.getSlot0` confirms that pool is still initialized on the canonical PoolManager (sqrtPriceX96 ≠ 0). Token addresses / whitelist / stablecoins are factory-independent and unchanged.

## On-chain verification (MegaETH mainnet, 4326)
- Canonical PoolManager `0xacb7e78f…` first has bytecode at block **7,009,653**; PositionManager `0x9ae0921e…` at block **7,009,656** (canonical Jan-30-2026 deployment batch, alongside the canonical v2 factory @ 7,009,645 and v3 factory @ 7,009,646).
- Old PoolManager `0x58dd83c3…` and new are identical bytecode size (24,009 B) — both real PoolManagers, the configured one is just the deprecated deployment.

## Follow-up
Redeploy the megaeth v4 subgraph after merge.