### PR TITLE
add arc-mainnet (5042) support

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -211,6 +211,16 @@
       "startBlock": 7009656
     }
   },
+  "arc-mainnet": {
+    "PoolManager": {
+      "address": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
+      "startBlock": 1948011
+    },
+    "PositionManager": {
+      "address": "0x6049c9a0e26405c0985f9e3685c87d0ae917f82b",
+      "startBlock": 1948011
+    }
+  },
   "linea": {
     "PoolManager": {
       "address": "0x248083fb965359d82b06c1f5322480dcfc1ad857",

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -720,6 +720,7 @@ export function getSubgraphConfig(): SubgraphConfig {
     const EURC = '0x89b50855aa3be2f677cd6303cec089b5f319d72a'.toLowerCase()
     const USYC = '0xe9185f0c5f296ed1797aae4238d26ccabeadb86c'.toLowerCase()
     const CIRBTC = '0x171a4217b86a807a64eb94757db6849fb4bdbaa0'.toLowerCase() // BTC-pegged; whitelist only
+    const WETH = '0x128cc466b61f542da60c70e3aa11c10e19b84edb'.toLowerCase() // bridged ETH; whitelist only (not the native/reference)
     return {
       poolManagerAddress: '0x8366a39cc670b4001a1121b8f6a443a643e40951'.toLowerCase(),
       stablecoinWrappedNativePoolId: '',
@@ -727,7 +728,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       wrappedNativeAddress: USDC,
       minimumNativeLocked: BigDecimal.fromString('2000'),
       stablecoinAddresses: [USDC],
-      whitelistTokens: [USDC, EURC, USYC, CIRBTC],
+      whitelistTokens: [USDC, EURC, USYC, CIRBTC, WETH],
       tokenOverrides: [],
       poolsToSkip: [],
       poolMappings: [],

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -30,6 +30,7 @@ const XLAYER_MAINNET_NETWORK_NAME = 'xlayer-mainnet'
 const MEGAETH_MAINNET_NETWORK_NAME = 'megaeth-mainnet'
 const LINEA_MAINNET_NETWORK_NAME = 'linea'
 const TEMPO_NETWORK_NAME = 'tempo'
+const ARC_MAINNET_NETWORK_NAME = 'arc-mainnet'
 
 // Note: All token and pool addresses should be lowercased!
 export class SubgraphConfig {
@@ -707,6 +708,34 @@ export function getSubgraphConfig(): SubgraphConfig {
       nativeTokenDetails: {
         symbol: 'ETH',
         name: 'Ethereum',
+        decimals: BigInt.fromI32(18),
+      },
+    }
+  } else if (selectedNetwork == ARC_MAINNET_NETWORK_NAME) {
+    // Arc (chainId 5042) is Circle's USDC-native L1: the native gas token is USDC and there is no
+    // wrapped native (the deployment's "WETH9" slot is the UnsupportedProtocol stub), so USDC is the
+    // reference token. Reference == the dollar ⇒ native price is 1: stablecoinWrappedNativePoolId is
+    // '' (the sentinel handled in getNativePriceInUSD).
+    const USDC = '0x3600000000000000000000000000000000000000'.toLowerCase()
+    const EURC = '0x89b50855aa3be2f677cd6303cec089b5f319d72a'.toLowerCase()
+    const USYC = '0xe9185f0c5f296ed1797aae4238d26ccabeadb86c'.toLowerCase()
+    const CIRBTC = '0x171a4217b86a807a64eb94757db6849fb4bdbaa0'.toLowerCase() // BTC-pegged; whitelist only
+    return {
+      poolManagerAddress: '0x8366a39cc670b4001a1121b8f6a443a643e40951'.toLowerCase(),
+      stablecoinWrappedNativePoolId: '',
+      stablecoinIsToken0: false,
+      wrappedNativeAddress: USDC,
+      minimumNativeLocked: BigDecimal.fromString('2000'),
+      stablecoinAddresses: [USDC],
+      whitelistTokens: [USDC, EURC, USYC, CIRBTC],
+      tokenOverrides: [],
+      poolsToSkip: [],
+      poolMappings: [],
+      nativeTokenDetails: {
+        // address(0) native currency = Arc's USDC gas token, which uses 18-dec precision
+        // (the USDC ERC-20 interface at 0x3600... is 6-dec and read on-chain separately)
+        symbol: 'USDC',
+        name: 'USD Coin',
         decimals: BigInt.fromI32(18),
       },
     }

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -17,13 +17,22 @@ export function sqrtPriceX96ToTokenPrices(
 
   const num = sqrtPriceX96.times(sqrtPriceX96).toBigDecimal()
   const denom = BigDecimal.fromString(Q192.toString())
-  const price1 = num.div(denom).times(exponentToBigDecimal(token0Decimals)).div(exponentToBigDecimal(token1Decimals))
+  const price1 = num
+    .div(denom)
+    .times(exponentToBigDecimal(token0Decimals))
+    .div(exponentToBigDecimal(token1Decimals))
 
   const price0 = safeDiv(BigDecimal.fromString('1'), price1)
   return [price0, price1]
 }
 
 export function getNativePriceInUSD(stablecoinWrappedNativePoolId: string, stablecoinIsToken0: boolean): BigDecimal {
+  // On chains where the native/reference token is itself a USD stablecoin (e.g. Arc, whose native
+  // gas token is USDC and which has no wrapped-native / reference-stable pool), the native price is
+  // 1 by definition. Such chains opt in by setting stablecoinWrappedNativePoolId to '' (empty).
+  if (stablecoinWrappedNativePoolId == '') {
+    return ONE_BD
+  }
   const stablecoinWrappedNativePool = Pool.load(stablecoinWrappedNativePoolId)
   if (stablecoinWrappedNativePool !== null) {
     return stablecoinIsToken0 ? stablecoinWrappedNativePool.token0Price : stablecoinWrappedNativePool.token1Price


### PR DESCRIPTION
Adds **Arc mainnet** (chainId 5042, Circle's USDC-native L1) to the v4 subgraph.

Arc's native gas token is USDC and there's no wrapped native (the deployment's "WETH9" slot is the `UnsupportedProtocol` stub), so **USDC is the reference token**. Because the reference token *is* the dollar, the native price is **1** — opted in via `stablecoinWrappedNativePoolId: ''`, with the sentinel handled in `getNativePriceInUSD` (which **both** the poolManager and swap call sites use, so the static-price path stays consistent and other chains are unaffected). Mirrors the v3/v2 approach; conceptually the same as how `tempo` is treated as a $1 reference.

**Changes**
- `src/utils/pricing.ts` — `getNativePriceInUSD` returns `ONE_BD` when `stablecoinWrappedNativePoolId == ''`.
- `src/utils/chains.ts` — `arc-mainnet` branch in `getSubgraphConfig` (PoolManager `0x8366a39c…`, `wrappedNativeAddress = USDC`, whitelist `[USDC, EURC, USYC, cirBTC]`, stablecoins `[USDC]`) + `ARC_MAINNET_NETWORK_NAME`.
- `networks.json` — PoolManager `0x8366a39c…` + PositionManager `0x6049c9a0…` @ startBlock **1948011**.

**Note to verify:** `nativeTokenDetails` (the address(0) native currency) is set to **18 dec** (Arc's native USDC gas token); the USDC ERC-20 interface `0x3600…` is 6-dec and read on-chain. Arc just launched so there's ~no v4 liquidity yet — the native-vs-ERC-20 USDC handling is worth a re-check once real v4 pools exist (I couldn't inspect arc's gated RPC/explorer). Indexing works regardless. cirBTC (`0x171A4217…`) is BTC-pegged so whitelisted but excluded from stablecoins.

Addresses per [5042.md](https://github.com/Uniswap/contracts/blob/main/deployments/5042.md); startBlock from explorer.arc.io.