### PR TITLE
add ink (57073) support

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -254,5 +254,15 @@
       "address": "0x7169a78a59f136876e724b648fbb339a42f46888",
       "startBlock": 6606180
     }
+  },
+  "ink": {
+    "PoolManager": {
+      "address": "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+      "startBlock": 4580556
+    },
+    "PositionManager": {
+      "address": "0x1b35d13a2e2528f192637f14b05f0dc0e7deb566",
+      "startBlock": 4580572
+    }
   }
 }

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -31,6 +31,7 @@ const MEGAETH_MAINNET_NETWORK_NAME = 'megaeth-mainnet'
 const LINEA_MAINNET_NETWORK_NAME = 'linea'
 const TEMPO_NETWORK_NAME = 'tempo'
 const ROBINHOOD_MAINNET_NETWORK_NAME = 'robinhood-mainnet'
+const INK_NETWORK_NAME = 'ink'
 const ARC_MAINNET_NETWORK_NAME = 'arc-mainnet'
 
 // Note: All token and pool addresses should be lowercased!
@@ -821,6 +822,29 @@ export function getSubgraphConfig(): SubgraphConfig {
         symbol: 'pathUSD',
         name: 'PathUSD',
         decimals: BigInt.fromI32(6),
+      },
+    }
+  } else if (selectedNetwork == INK_NETWORK_NAME) {
+    const NATIVE_ETH = '0x0000000000000000000000000000000000000000'.toLowerCase()
+    const WETH = '0x4200000000000000000000000000000000000006'.toLowerCase()
+    const USDT0 = '0x0200C29006150606B650577BBE7B6248F58470c1'.toLowerCase()
+    const USDCE = '0xF1815bd50389c46847f0Bda824eC8da914045D14'.toLowerCase()
+    const ETH_USDT0_POOL = '0x26354d494b48cc544076d4afe855b5bf224e6a5d4e403bbbf04cbc7f25790b90'.toLowerCase()
+    return {
+      poolManagerAddress: '0x360e68faccca8ca495c1b759fd9eee466db9fb32',
+      stablecoinWrappedNativePoolId: ETH_USDT0_POOL,
+      stablecoinIsToken0: false,
+      wrappedNativeAddress: NATIVE_ETH,
+      minimumNativeLocked: BigDecimal.fromString('1'),
+      stablecoinAddresses: [USDT0, USDCE],
+      whitelistTokens: [WETH, NATIVE_ETH, USDT0, USDCE],
+      tokenOverrides: [],
+      poolsToSkip: [],
+      poolMappings: [],
+      nativeTokenDetails: {
+        symbol: 'ETH',
+        name: 'Ethereum',
+        decimals: BigInt.fromI32(18),
       },
     }
   } else {


### PR DESCRIPTION
## Summary
- Adds Ink (chain 57073) as a supported network for the v4 subgraph.
- **PoolManager** `0x360e68faccca8ca495c1b759fd9eee466db9fb32` at block **4580556**.
- **PositionManager** `0x1b35d13a2e2528f192637f14b05f0dc0e7deb566` at block **4580572**.
- USD price anchored on the **native ETH / USDT0** v4 pool `0x26354d494b48cc544076d4afe855b5bf224e6a5d4e403bbbf04cbc7f25790b90` — native ETH (`0x0000…0000`) is currency0, USDT0 (`0x0200C29…0c1`) is currency1, so `stablecoinIsToken0=false`.
- Whitelist: WETH (`0x4200…0006`), native ETH, USDT0, USDC.e (`0xF1815b…45D14`).
- Stablecoins: USDT0, USDC.e.

Mirrors the [v3-subgraph PR #303](https://github.com/Uniswap/v3-subgraph/pull/303) for the same chain.

Deployment data from [Uniswap/contracts#153](https://github.com/Uniswap/contracts/pull/153) ([PROTO-1474](https://linear.app/uniswap/issue/PROTO-1474/protocol-deployment)); start blocks resolved by querying Ink RPC for the deployment transaction receipts.

## Test plan
- [x] `yarn generate-subgraph ink` succeeds
- [x] `yarn build` (codegen + graph build) succeeds — AssemblyScript compiles cleanly with the new branch
- [ ] Deploy to Alchemy hosted service and verify PoolManager + PositionManager start indexing at the listed blocks
- [ ] Verify the ETH/USDT0 pool is indexed and USD prices derive correctly via this pool

Note: `yarn lint` reports errors only in `generated/` (auto-generated by `graph codegen` / `graph build`, gitignored but not in `.eslintignore`). Pre-existing on main — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)