### PR TITLE
fix: restore green CI (lint gate + two latent test breakages)

### DIFF
--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -17,10 +17,8 @@ export function sqrtPriceX96ToTokenPrices(
 
   const num = sqrtPriceX96.times(sqrtPriceX96).toBigDecimal()
   const denom = BigDecimal.fromString(Q192.toString())
-  const price1 = num
-    .div(denom)
-    .times(exponentToBigDecimal(token0Decimals))
-    .div(exponentToBigDecimal(token1Decimals))
+  const priceRatio = num.div(denom).times(exponentToBigDecimal(token0Decimals))
+  const price1 = priceRatio.div(exponentToBigDecimal(token1Decimals))
 
   const price0 = safeDiv(BigDecimal.fromString('1'), price1)
   return [price0, price1]

--- a/tests/handlers/constants.ts
+++ b/tests/handlers/constants.ts
@@ -112,8 +112,8 @@ export const USDC_WETH_05_MAINNET_POOL_FIXTURE: PoolFixture = {
   tickSpacing: '10',
   liquidity: '100',
   hooks: ADDRESS_ZERO,
-  sqrtPrice: '1',
-  tick: '1',
+  sqrtPrice: '79228162514264337514315787821',
+  tick: '-1',
 }
 
 export const WBTC_WETH_03_MAINNET_POOL_FIXTURE: PoolFixture = {
@@ -275,6 +275,7 @@ export const createAndStoreTestPool = (poolFixture: PoolFixture): Pool => {
   pool.totalValueLockedUSDUntracked = ZERO_BD
   pool.liquidityProviderCount = ZERO_BI
   pool.hooks = ADDRESS_ZERO
+  pool.isExternalLiquidity = false
 
   pool.save()
   return pool


### PR DESCRIPTION
## Problem
CI has been red on `main`. The `lint` job fails, and because `build-and-test`
is gated on it (`needs: lint`), the test suite hasn't run — which hid two
further breakages that surface once lint passes.

## Fixes (test/tooling only — no mapping behavior changes)
1. **lint** — `src/utils/pricing.ts`: the `prettier/prettier` error was an
   unwinnable conflict between the pre-commit hook's prettier (1.19.1, breaks
   the `num.div().times().div()` chain onto multiple lines) and CI's
   eslint-prettier (newer, wants one line). Split the chain into two
   statements so both agree. Behavior-identical.
2. **fixture panic** — `tests/handlers/constants.ts`: set the non-nullable
   `isExternalLiquidity` on the shared pool fixture so `Pool.save()` no longer
   panics and aborts the whole run (field added in #72, fixture never updated).
3. **handleSwap** — `tests/handlers/constants.ts`: seed the USDC/WETH fixture
   with a realistic `sqrtPrice` (was `'1'`, a placeholder that yields a
   nonsensical ~Q192 price). Combined with the removal of an intermediate
   `pool.save()` in #45, that placeholder leaked a stale garbage price into
   the swap's USD accounting. A real price restores the assertion.

## Verification
Lint clean and all 62 tests pass via the same matchstick 0.6.0 Docker image CI
uses (`build-and-test` green end to end).