### PR TITLE
fix(robinhood): set WETH/USDG reference pool for USD pricing

### DIFF
--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -715,15 +715,14 @@ export function getSubgraphConfig(): SubgraphConfig {
     }
   } else if (selectedNetwork == ROBINHOOD_MAINNET_NETWORK_NAME) {
     // Robinhood chain (4663) — standard ETH-native config. Reference is WETH (and native ETH =
-    // address(0)), priced via the (native) ETH/USDG v4 pool. stablecoinWrappedNativePoolId is a
-    // zero placeholder until that pool is created + seeded → USD reads 0 until then (indexing works).
-    // NOT the Arc '' sentinel (which forces a native price of 1) — WETH/ETH is a volatile reference.
+    // address(0)), priced via the (native) ETH/USDG v4 pool. NOT the Arc '' sentinel (which forces
+    // a native price of 1) — WETH/ETH is a volatile reference.
     const WETH = '0x0bd7d308f8e1639fab988df18a8011f41eacad73'.toLowerCase()
     const USDG = '0x5fc5360d0400a0fd4f2af552add042d716f1d168'.toLowerCase()
     return {
       poolManagerAddress: '0x8366a39cc670b4001a1121b8f6a443a643e40951'.toLowerCase(),
-      stablecoinWrappedNativePoolId: '0x0000000000000000000000000000000000000000000000000000000000000000', // TODO: ETH/USDG v4 poolId once seeded
-      stablecoinIsToken0: false, // TODO: confirm ordering when the ETH/USDG pool exists (native ETH = 0x0 < USDG ⇒ USDG is token1)
+      stablecoinWrappedNativePoolId: '0x387bf619da4d3fb62bb276482693dba1b9b3520f573cabdfe033384a24125982', // ETH/USDG v4 pool
+      stablecoinIsToken0: false, // native ETH (0x0) is token0, USDG is token1
       wrappedNativeAddress: WETH,
       minimumNativeLocked: BigDecimal.fromString('1'),
       stablecoinAddresses: [USDG],


### PR DESCRIPTION
Sets the WETH/USDG reference pool for Robinhood so the subgraph can derive ETH→USD pricing (was a zero/empty placeholder → ethPriceUSD=0 → all pools reported $0 TVL/volume).

Reference pools (verified live, ~2 ETH liquidity each):
- v2 pair: 0x8803c117ccae7b5146297876c2a25df135141c4d
- v3 pool: 0x69bfaf19c9f377bb306a89aed9f6b07e2c1a8d9a
- v4 pool: 0x387bf619da4d3fb62bb276482693dba1b9b3520f573cabdfe033384a24125982

2.0.0 versions already deployed to Goldsky and verified (ethPriceUSD ~$1340, USD TVL/volume populating); this PR lands the config so future redeploys don't regress to the placeholder.